### PR TITLE
Adding option to configure timezone for the schedules

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ notifications:
 |---|---|---|
 | `name` | Yes | This name can be used to reference the object from other repositories as well. |
 | `schedule` | Yes | Cron schedule pattern that supports seconds as well, first position is the seconds. More on the format [here](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html#format). |
+| `timezone` | No | Timezone to adjust the schedule to. Defaults to `UTC`. |
 | `type` | Yes | The only supported `type` is `slack/channel`. |
 | `config` | No | Depends on the `type` field's value, each notification type may have different configuration. |
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ enabled: true
 notifications:
   - name: slack-notification
     schedule: "*/30 * * * * ?"
+    timezone: "EST"
     type: slack/channel
     config:
       channel: "test-channel"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.14"
 services:
   app:
-    image: openjdk:11
+    image: openjdk:17
     volumes:
       - ./:/sources
     working_dir: /sources

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,9 @@
 	<name>github-scheduled-reminder-app</name>
 	<description>github-scheduled-reminder-app</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>15</java.version>
+		<maven.compiler.source>15</maven.compiler.source>
+		<maven.compiler.target>15</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -89,6 +91,10 @@
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-storage</artifactId>
 			<version>2.1.9</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,7 @@
 	<name>github-scheduled-reminder-app</name>
 	<description>github-scheduled-reminder-app</description>
 	<properties>
-		<java.version>15</java.version>
-		<maven.compiler.source>15</maven.compiler.source>
-		<maven.compiler.target>15</maven.compiler.target>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/Config.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/Config.java
@@ -9,6 +9,8 @@ import com.bbaga.githubscheduledreminderapp.infrastructure.GitHub.GitHubBuilderF
 import com.bbaga.githubscheduledreminderapp.jobs.GitHubInstallationScan;
 import com.bbaga.githubscheduledreminderapp.jobs.ScheduledStateDump;
 import com.bbaga.githubscheduledreminderapp.repositories.GitHubInstallationRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.hubspot.slack.client.SlackClient;
 import com.hubspot.slack.client.SlackClientFactory;
 import com.hubspot.slack.client.SlackClientRuntimeConfig;
@@ -201,7 +203,9 @@ public class Config {
 
     @Bean
     public InRepoConfigParser getInRepoConfigParser(@Qualifier("application.configFilePath") String configFilePath) {
-        return new InRepoConfigParser(new Yaml(), configFilePath);
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.findAndRegisterModules();
+        return new InRepoConfigParser(mapper, configFilePath);
     }
 
     @Bean

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParser.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParser.java
@@ -1,23 +1,23 @@
 package com.bbaga.githubscheduledreminderapp.configuration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHRepository;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class InRepoConfigParser {
-    private final Yaml yaml;
+    private final ObjectMapper mapper;
     private final String configFilePath;
 
-    public InRepoConfigParser(Yaml yaml, String configFilePath) {
-        this.yaml = yaml;
+    public InRepoConfigParser(ObjectMapper mapper, String configFilePath) {
+        this.mapper = mapper;
         this.configFilePath = configFilePath;
     }
 
     public InRepoConfig getFrom(GHRepository repository) throws IOException {
         GHContent content = repository.getFileContent(configFilePath);
-        return yaml.loadAs(new String(content.read().readAllBytes(), StandardCharsets.UTF_8), InRepoConfig.class);
+        return mapper.readValue(new String(content.read().readAllBytes(), StandardCharsets.UTF_8), InRepoConfig.class);
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/configuration/Notification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/configuration/Notification.java
@@ -1,13 +1,20 @@
 package com.bbaga.githubscheduledreminderapp.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.HashMap;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Notification {
     private String name;
     private String schedule;
     private String type;
     private Extending extending;
     private HashMap<String, ?> config = new HashMap<>();
+
+    @JsonProperty("timezone")
+    private String timeZone = "UTC";
 
     public Notification() {}
 
@@ -61,5 +68,13 @@ public class Notification {
 
     public void setExtending(Extending extending) {
         this.extending = extending;
+    }
+
+    public String getTimeZone() {
+        return timeZone;
+    }
+
+    public void setTimeZone(String timeZone) {
+        this.timeZone = timeZone;
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/jobs/GitHubInstallationRepositoryScan.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/jobs/GitHubInstallationRepositoryScan.java
@@ -125,8 +125,10 @@ public class GitHubInstallationRepositoryScan implements Job {
                                 .storeDurably(true)
                                 .build();
 
+                        TimeZone timeZone = TimeZone.getTimeZone(node.getNotification().getTimeZone());
+
                         trigger = TriggerBuilder.newTrigger()
-                                .withSchedule(CronScheduleBuilder.cronSchedule(node.getNotification().getSchedule()))
+                                .withSchedule(CronScheduleBuilder.cronSchedule(node.getNotification().getSchedule()).inTimeZone(timeZone))
                                 .withIdentity(jobKey.getName()).build();
 
                         scheduler.scheduleJob(job, trigger);

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParserTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParserTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.kohsuke.github.GHContent;
 import org.kohsuke.github.GHRepository;
 import org.mockito.Mockito;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParserTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/InRepoConfigParserTest.java
@@ -1,0 +1,131 @@
+package com.bbaga.githubscheduledreminderapp.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHContent;
+import org.kohsuke.github.GHRepository;
+import org.mockito.Mockito;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+class InRepoConfigParserTest {
+
+    @Test
+    void parseScheduleConfigTest() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        String configPath = "path/to/config.yaml";
+        String config = """
+enabled: true
+notifications:
+  - name: testing
+    schedule: "0 1 2 3 4 5 6"
+    type: slack/channel
+    config:
+      channel: "test-channel"
+""";
+
+        InputStream stream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8));
+
+        GHContent content = Mockito.mock(GHContent.class);
+        Mockito.doReturn(stream).when(content).read();
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        Mockito.doReturn(content).when(repository).getFileContent(configPath);
+
+        InRepoConfigParser parser = new InRepoConfigParser(mapper, configPath);
+
+        InRepoConfig parsedConfig = parser.getFrom(repository);
+
+        Assertions.assertEquals(true, parsedConfig.getEnabled());
+        Assertions.assertEquals(1, parsedConfig.getNotifications().size());
+
+        Notification notification = parsedConfig.getNotifications().get(0);
+        Assertions.assertEquals("testing", notification.getName());
+        Assertions.assertEquals("0 1 2 3 4 5 6", notification.getSchedule());
+        Assertions.assertEquals("UTC", notification.getTimeZone());
+        Assertions.assertEquals("slack/channel", notification.getType());
+
+        HashMap<String, ?> notificationConfig = notification.getConfig();
+        Assertions.assertEquals("test-channel", notificationConfig.get("channel"));
+    }
+
+    @Test
+    void parseScheduleConfigWithTimeZoneTest() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        String configPath = "path/to/config.yaml";
+        String config = """
+enabled: true
+notifications:      
+  - name: timezone
+    schedule: "* * * * * *"
+    type: slack/channel
+    timezone: EST
+    config:
+      channel: "dev-channel"
+""";
+
+        InputStream stream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8));
+
+        GHContent content = Mockito.mock(GHContent.class);
+        Mockito.doReturn(stream).when(content).read();
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        Mockito.doReturn(content).when(repository).getFileContent(configPath);
+
+        InRepoConfigParser parser = new InRepoConfigParser(mapper, configPath);
+
+        InRepoConfig parsedConfig = parser.getFrom(repository);
+
+        Assertions.assertEquals(true, parsedConfig.getEnabled());
+        Assertions.assertEquals(1, parsedConfig.getNotifications().size());
+
+        Notification notification = parsedConfig.getNotifications().get(0);
+        Assertions.assertEquals("timezone", notification.getName());
+        Assertions.assertEquals("* * * * * *", notification.getSchedule());
+        Assertions.assertEquals("EST", notification.getTimeZone());
+        Assertions.assertEquals("slack/channel", notification.getType());
+
+        HashMap<String, ?> notificationConfig = notification.getConfig();
+        Assertions.assertEquals("dev-channel", notificationConfig.get("channel"));
+    }
+
+    @Test
+    void parseExtensionConfigTest() throws IOException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        String configPath = "path/to/config.yaml";
+        String config = """
+enabled: true
+notifications:
+  - extending:
+      repository: some/repository
+      name: something
+""";
+
+        InputStream stream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8));
+
+        GHContent content = Mockito.mock(GHContent.class);
+        Mockito.doReturn(stream).when(content).read();
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        Mockito.doReturn(content).when(repository).getFileContent(configPath);
+
+        InRepoConfigParser parser = new InRepoConfigParser(mapper, configPath);
+
+        InRepoConfig parsedConfig = parser.getFrom(repository);
+
+        Assertions.assertEquals(true, parsedConfig.getEnabled());
+        Assertions.assertEquals(1, parsedConfig.getNotifications().size());
+
+        Notification notification = parsedConfig.getNotifications().get(0);
+        Extending extension = notification.getExtending();
+        Assertions.assertEquals("some/repository", extension.getRepository());
+        Assertions.assertEquals("something", extension.getName());
+    }
+}

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/NotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/configuration/NotificationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,6 +48,16 @@ class NotificationTest {
         notification.setConfig(map);
 
         assertEquals("bar", notification.getConfig().get("foo"));
+    }
+
+    @Test
+    void testTimeZone() {
+        TimeZone tz = TimeZone.getTimeZone(notification.getTimeZone());
+        assertEquals("Coordinated Universal Time", tz.getDisplayName());
+
+        notification.setTimeZone("EST");
+        tz = TimeZone.getTimeZone(notification.getTimeZone());
+        assertEquals("Eastern Standard Time", tz.getDisplayName());
     }
 
     @Test


### PR DESCRIPTION
Adding timezone support for the schedules.
Introduced new field in the configuration called `timezone` and expects the values to be the string representation of the time zones.

### Example
```yaml
notifications:
  - name: slack-notification
    schedule: "0 0 14 * * ?"
    timezone: "EST"
    ...
```

Closes #15 