### PR TITLE
Create scheduled job when updating the config through /state/update

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/Config.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/Config.java
@@ -8,6 +8,7 @@ import com.bbaga.githubscheduledreminderapp.configuration.persistence.ConfigPers
 import com.bbaga.githubscheduledreminderapp.infrastructure.GitHub.GitHubBuilderFactory;
 import com.bbaga.githubscheduledreminderapp.jobs.GitHubInstallationScan;
 import com.bbaga.githubscheduledreminderapp.jobs.ScheduledStateDump;
+import com.bbaga.githubscheduledreminderapp.jobs.scheduling.NotificationJobScheduler;
 import com.bbaga.githubscheduledreminderapp.repositories.GitHubInstallationRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -196,9 +197,9 @@ public class Config {
     @Bean
     public ConfigGraphUpdater getConfigGraphUpdater(
         @Qualifier("ConfigGraph") ConcurrentHashMap<String, ConfigGraphNode> configGraph,
-        @Qualifier("Scheduler") Scheduler scheduler
+        NotificationJobScheduler notificationJobScheduler
     ) {
-        return new ConfigGraphUpdater(configGraph, scheduler);
+        return new ConfigGraphUpdater(configGraph, notificationJobScheduler);
     }
 
     @Bean
@@ -211,5 +212,10 @@ public class Config {
     @Bean
     public GitHubBuilderFactory getGitHubBuilderFactory(@Qualifier("application.gitHubEndpoint") String gitHubEndpoint) {
         return new GitHubBuilderFactory(gitHubEndpoint);
+    }
+
+    @Bean
+    public NotificationJobScheduler getNotificationJobScheduler(@Qualifier("Scheduler") Scheduler scheduler) {
+        return new NotificationJobScheduler(scheduler);
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/jobs/scheduling/NotificationJobScheduler.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/jobs/scheduling/NotificationJobScheduler.java
@@ -1,0 +1,41 @@
+package com.bbaga.githubscheduledreminderapp.jobs.scheduling;
+
+import com.bbaga.githubscheduledreminderapp.configuration.Notification;
+import com.bbaga.githubscheduledreminderapp.jobs.ScheduledNotification;
+import org.quartz.*;
+
+import java.util.TimeZone;
+
+public class NotificationJobScheduler {
+    private final Scheduler scheduler;
+
+    public NotificationJobScheduler(Scheduler scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void createSchedule(Notification notification) throws SchedulerException {
+        JobKey jobKey = new JobKey(notification.getName());
+
+        JobDetail job = JobBuilder.newJob(ScheduledNotification.class)
+            .withIdentity(jobKey)
+            .storeDurably(true)
+            .build();
+
+        TimeZone timeZone = TimeZone.getTimeZone(notification.getTimeZone());
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withSchedule(CronScheduleBuilder.cronSchedule(notification.getSchedule()).inTimeZone(timeZone))
+            .withIdentity(jobKey.getName()).build();
+
+        scheduler.scheduleJob(job, trigger);
+    }
+
+    public void updateSchedule(Notification notification) throws SchedulerException {
+        TimeZone timeZone = TimeZone.getTimeZone(notification.getTimeZone());
+
+        Trigger newTrigger = TriggerBuilder.newTrigger()
+            .withSchedule(CronScheduleBuilder.cronSchedule(notification.getSchedule()).inTimeZone(timeZone))
+            .withIdentity(notification.getName()).build();
+        scheduler.rescheduleJob(new TriggerKey(notification.getName()), newTrigger);
+    }
+}

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/jobs/scheduling/NotificationJobSchedulerTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/jobs/scheduling/NotificationJobSchedulerTest.java
@@ -1,0 +1,70 @@
+package com.bbaga.githubscheduledreminderapp.jobs.scheduling;
+
+import com.bbaga.githubscheduledreminderapp.configuration.Notification;
+import com.bbaga.githubscheduledreminderapp.jobs.ScheduledNotification;
+import com.bbaga.githubscheduledreminderapp.notifications.slack.ChannelNotificationDataProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.quartz.*;
+
+import java.util.TimeZone;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NotificationJobSchedulerTest {
+
+    private Scheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        this.scheduler = Mockito.mock(Scheduler.class);
+    }
+
+    @Test
+    void createSchedule() throws SchedulerException {
+        Notification notification = new Notification();
+        notification.setName("test-schedule");
+        notification.setSchedule("* * * * * ?");
+        notification.setTimeZone("Europe/Berlin");
+
+        NotificationJobScheduler jobScheduler = new NotificationJobScheduler(this.scheduler);
+        jobScheduler.createSchedule(notification);
+
+        ArgumentCaptor<JobDetail> jobDetailCaptor = ArgumentCaptor.forClass(JobDetail.class);
+        ArgumentCaptor<CronTrigger> triggerCaptor = ArgumentCaptor.forClass(CronTrigger.class);
+
+        Mockito.verify(this.scheduler, Mockito.times(1)).scheduleJob(jobDetailCaptor.capture(), triggerCaptor.capture());
+
+        JobDetail capturedJobDetail = jobDetailCaptor.getValue();
+        CronTrigger capturedTrigger = triggerCaptor.getValue();
+
+        assertEquals(notification.getName(), capturedJobDetail.getKey().getName());
+        assertEquals(notification.getName(), capturedTrigger.getKey().getName());
+        assertEquals(notification.getSchedule(), capturedTrigger.getCronExpression());
+        assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
+    }
+
+    @Test
+    void updateSchedule() throws SchedulerException {
+        Notification notification = new Notification();
+        notification.setName("test-schedule");
+        notification.setSchedule("* * * * * ?");
+        notification.setTimeZone("Europe/Berlin");
+
+        NotificationJobScheduler jobScheduler = new NotificationJobScheduler(this.scheduler);
+        jobScheduler.updateSchedule(notification);
+
+        ArgumentCaptor<TriggerKey> triggerKeyCaptor = ArgumentCaptor.forClass(TriggerKey.class);
+        ArgumentCaptor<CronTrigger> triggerCaptor = ArgumentCaptor.forClass(CronTrigger.class);
+
+        Mockito.verify(this.scheduler, Mockito.times(1)).rescheduleJob(triggerKeyCaptor.capture(), triggerCaptor.capture());
+
+        TriggerKey capturedTriggerKey = triggerKeyCaptor.getValue();
+        CronTrigger capturedTrigger = triggerCaptor.getValue();
+
+        assertEquals(notification.getName(), capturedTriggerKey.getName());
+        assertEquals(notification.getSchedule(), capturedTrigger.getCronExpression());
+        assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
+    }
+}


### PR DESCRIPTION
Creating schedule when config is "manually" updated using the `/state/update` endpoint.

Closes #20 