### PR TITLE
Avoiding null pointer exception on wrong config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.bbaga</groupId>
 	<artifactId>github-scheduled-reminder-app</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.3.1-SNAPSHOT</version>
 	<name>github-scheduled-reminder-app</name>
 	<description>github-scheduled-reminder-app</description>
 	<properties>
@@ -97,6 +97,11 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jdk8</artifactId>
+			<version>2.9.6</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Extending.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Extending.java
@@ -1,8 +1,8 @@
 package com.bbaga.githubscheduledreminderapp.domain.configuration;
 
 public class Extending {
-    private String repository;
-    private String name;
+    private String repository = "";
+    private String name = "";
 
     public String getRepository() {
         return repository;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Notification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Notification.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Notification {
-    private String name;
+    private String name = "";
     private String schedule;
-    private String type;
+    private String type = "";
     private Extending extending;
     private HashMap<String, ?> config = new HashMap<>();
 
@@ -38,8 +39,8 @@ public class Notification {
         this.name = name;
     }
 
-    public String getSchedule() {
-        return schedule;
+    public Optional<String> getSchedule() {
+        return Optional.ofNullable(schedule);
     }
 
     public void setSchedule(String schedule) {
@@ -62,8 +63,8 @@ public class Notification {
         this.config = config;
     }
 
-    public Extending getExtending() {
-        return extending;
+    public Optional<Extending> getExtending() {
+        return Optional.ofNullable(extending);
     }
 
     public void setExtending(Extending extending) {

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobScheduler.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobScheduler.java
@@ -4,6 +4,7 @@ import com.bbaga.githubscheduledreminderapp.domain.configuration.Notification;
 import com.bbaga.githubscheduledreminderapp.application.jobs.ScheduledNotification;
 import org.quartz.*;
 
+import java.util.Optional;
 import java.util.TimeZone;
 
 public class NotificationJobScheduler {
@@ -14,6 +15,12 @@ public class NotificationJobScheduler {
     }
 
     public void createSchedule(Notification notification) throws SchedulerException {
+        Optional<String> schedule = notification.getSchedule();
+
+        if (schedule.isEmpty()) {
+            return;
+        }
+
         JobKey jobKey = new JobKey(notification.getName());
 
         JobDetail job = JobBuilder.newJob(ScheduledNotification.class)
@@ -24,17 +31,23 @@ public class NotificationJobScheduler {
         TimeZone timeZone = TimeZone.getTimeZone(notification.getTimeZone());
 
         Trigger trigger = TriggerBuilder.newTrigger()
-            .withSchedule(CronScheduleBuilder.cronSchedule(notification.getSchedule()).inTimeZone(timeZone))
+            .withSchedule(CronScheduleBuilder.cronSchedule(schedule.get()).inTimeZone(timeZone))
             .withIdentity(jobKey.getName()).build();
 
         scheduler.scheduleJob(job, trigger);
     }
 
     public void updateSchedule(Notification notification) throws SchedulerException {
+        Optional<String> schedule = notification.getSchedule();
+
+        if (schedule.isEmpty()) {
+            return;
+        }
+
         TimeZone timeZone = TimeZone.getTimeZone(notification.getTimeZone());
 
         Trigger newTrigger = TriggerBuilder.newTrigger()
-            .withSchedule(CronScheduleBuilder.cronSchedule(notification.getSchedule()).inTimeZone(timeZone))
+            .withSchedule(CronScheduleBuilder.cronSchedule(schedule.get()).inTimeZone(timeZone))
             .withIdentity(notification.getName()).build();
         scheduler.rescheduleJob(new TriggerKey(notification.getName()), newTrigger);
     }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/RepositoryIssuesSource.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/RepositoryIssuesSource.java
@@ -1,0 +1,21 @@
+package com.bbaga.githubscheduledreminderapp.domain.sources.github;
+
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHRepository;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RepositoryIssuesSource {
+    public static Set<GHIssue> get(GHRepository repository) throws IOException {
+        Set<GHIssue> issues = new HashSet<>();
+        repository.getIssues(GHIssueState.OPEN).forEach((GHIssue issue) -> {
+            if (!issue.isPullRequest()) {
+                issues.add(issue);
+            }
+        });
+
+        return issues;
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/RepositoryPRsSource.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/RepositoryPRsSource.java
@@ -1,0 +1,27 @@
+package com.bbaga.githubscheduledreminderapp.domain.sources.github;
+
+import org.kohsuke.github.GHIssue;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RepositoryPRsSource {
+    public static Set<GHIssue> get(GHRepository repository) throws IOException {
+        Set<GHIssue> pullRequests = new HashSet<>();
+        repository.getPullRequests(GHIssueState.OPEN).forEach((GHPullRequest pr) -> {
+            try {
+                if (!pr.isDraft()) {
+                    pullRequests.add(pr);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
+
+        return pullRequests;
+    }
+}

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/NotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/NotificationTest.java
@@ -32,7 +32,7 @@ class NotificationTest {
         final String schedule = "* * * * *";
         notification.setSchedule(schedule);
 
-        assertEquals(schedule, notification.getSchedule());
+        assertEquals(schedule, notification.getSchedule().get());
     }
 
     @Test
@@ -69,8 +69,8 @@ class NotificationTest {
         extending.setRepository("repo");
         notification.setExtending(extending);
 
-        assertEquals("name", notification.getExtending().getName());
-        assertEquals("repo", notification.getExtending().getRepository());
+        assertEquals("name", notification.getExtending().get().getName());
+        assertEquals("repo", notification.getExtending().get().getRepository());
 
     }
 }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/RepositoryInstallationEventListenerTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/RepositoryInstallationEventListenerTest.java
@@ -107,7 +107,7 @@ class RepositoryInstallationEventListenerTest {
 
         Notification notification = notificationCaptor.getValue();
         assertEquals("testing", notification.getName());
-        assertEquals("* * * * * ?", notification.getSchedule());
+        assertEquals("* * * * * ?", notification.getSchedule().get());
 
         Long installationId = installationIdCaptor.getValue();
         assertEquals(987654321L, installationId);

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobSchedulerTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobSchedulerTest.java
@@ -40,7 +40,7 @@ class NotificationJobSchedulerTest {
 
         assertEquals(notification.getName(), capturedJobDetail.getKey().getName());
         assertEquals(notification.getName(), capturedTrigger.getKey().getName());
-        assertEquals(notification.getSchedule(), capturedTrigger.getCronExpression());
+        assertEquals(notification.getSchedule().get(), capturedTrigger.getCronExpression());
         assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
     }
 
@@ -63,7 +63,7 @@ class NotificationJobSchedulerTest {
         CronTrigger capturedTrigger = triggerCaptor.getValue();
 
         assertEquals(notification.getName(), capturedTriggerKey.getName());
-        assertEquals(notification.getSchedule(), capturedTrigger.getCronExpression());
+        assertEquals(notification.getSchedule().get(), capturedTrigger.getCronExpression());
         assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
     }
 }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
@@ -14,10 +14,8 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.time.Instant;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 class ChannelNotificationTest {
@@ -61,6 +59,7 @@ class ChannelNotificationTest {
             Mockito.when(issue.getHtmlUrl()).thenReturn(new URL("https://google.com"));
             Mockito.when(issue.getNodeId()).thenReturn("1234567");
             Mockito.when(issue.getRepository()).thenReturn(repository);
+            Mockito.when(issue.getCreatedAt()).thenReturn(Date.from(Instant.now()));
 
             Mockito.when(pr.getTitle()).thenReturn("PR title");
             Mockito.when(pr.getNumber()).thenReturn(1);
@@ -68,6 +67,7 @@ class ChannelNotificationTest {
             Mockito.when(pr.getHtmlUrl()).thenReturn(new URL("https://google.com"));
             Mockito.when(pr.getNodeId()).thenReturn("1234567");
             Mockito.when(pr.getRepository()).thenReturn(repository);
+            Mockito.when(pr.getCreatedAt()).thenReturn(Date.from(Instant.now()));
             Mockito.when(repository.getPullRequest(1)).thenReturn(pullRequest);
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,11 +35,10 @@ class ChannelNotificationTest {
         config.put("channel", "test");
         Notification notification = new Notification();
         notification.setConfig(config);
-        Set<GHIssue> issues = new HashSet<>();
-        Set<GHIssue> pullRequests = new HashSet<>();
+        ArrayList<GHIssue> issues = new ArrayList<>();
 
         Mockito.when(client.postMessage(Mockito.any())).thenReturn(future);
-        service.send(new ChannelNotificationDataProvider.Data(notification, issues, pullRequests));
+        service.send(new ChannelNotificationDataProvider.Data(notification, issues));
         Mockito.verify(client, Mockito.times(1)).postMessage(Mockito.any());
 
     }
@@ -82,13 +82,12 @@ class ChannelNotificationTest {
         config.put("channel", "test");
         Notification notification = new Notification();
         notification.setConfig(config);
-        Set<GHIssue> issues = new HashSet<>();
+        ArrayList<GHIssue> issues = new ArrayList<>();
         issues.add(issue);
-        Set<GHIssue> pullRequests = new HashSet<>();
-        pullRequests.add(pr);
+        issues.add(pr);
 
         Mockito.when(client.postMessage(Mockito.any())).thenReturn(future);
-        service.send(new ChannelNotificationDataProvider.Data(notification, issues, pullRequests));
+        service.send(new ChannelNotificationDataProvider.Data(notification, issues));
         Mockito.verify(client, Mockito.times(1)).postMessage(Mockito.any());
 
     }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfigParserTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfigParserTest.java
@@ -49,7 +49,7 @@ notifications:
 
         Notification notification = parsedConfig.getNotifications().get(0);
         Assertions.assertEquals("testing", notification.getName());
-        Assertions.assertEquals("0 1 2 3 4 5 6", notification.getSchedule());
+        Assertions.assertEquals("0 1 2 3 4 5 6", notification.getSchedule().get());
         Assertions.assertEquals("UTC", notification.getTimeZone());
         Assertions.assertEquals("slack/channel", notification.getType());
 
@@ -89,7 +89,7 @@ notifications:
 
         Notification notification = parsedConfig.getNotifications().get(0);
         Assertions.assertEquals("timezone", notification.getName());
-        Assertions.assertEquals("* * * * * *", notification.getSchedule());
+        Assertions.assertEquals("* * * * * *", notification.getSchedule().get());
         Assertions.assertEquals("EST", notification.getTimeZone());
         Assertions.assertEquals("slack/channel", notification.getType());
 
@@ -125,7 +125,7 @@ notifications:
         Assertions.assertEquals(1, parsedConfig.getNotifications().size());
 
         Notification notification = parsedConfig.getNotifications().get(0);
-        Extending extension = notification.getExtending();
+        Extending extension = notification.getExtending().get();
         Assertions.assertEquals("some/repository", extension.getRepository());
         Assertions.assertEquals("something", extension.getName());
     }


### PR DESCRIPTION
When encountered malformed configuration files where the both the `schedule` and `extends` fields were missing, the application ran into a null pointer exception.