### PR TITLE
Keep Java 11 compatibility in the application code

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,8 +10,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
-
+  build-17:
+    name: "Java 17"
     runs-on: ubuntu-latest
 
     steps:
@@ -24,3 +24,17 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+  build-11:
+    name: "Java 11"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package -Dmaven.test.skip --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,4 +37,4 @@ jobs:
         distribution: 'adopt'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package -Dmaven.test.skip --file pom.xml
+      run: sed -i 's|<java.version>17</java.version>|<java.version>11</java.version>|' pom.xml && mvn -B package -Dmaven.test.skip --file pom.xml

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -123,7 +123,7 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
             ageTemplate = ageTemplate + "s";
         }
 
-        return ageTemplate.formatted(units);
+        return String.format(ageTemplate, units);
     }
 
     private Section markdownSection(String pattern, Object... args) {


### PR DESCRIPTION
Apparently `.formatted()` method on strings isn't a thing in Java 11