### PR TITLE
Implement tracking capabilities of clicked links in notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,43 +64,43 @@ If the application doesn't work at this point, please open an issue.
 ### `GITHUB_ID`
 The GitHub application id as per the [App ID](#app-id) section.
 
-**Reqiured**: true
+**Required**: true
 
 ### `GITHUB_APP_CERT`
 Mandatory when `GITHUB_APP_CERT_FILE` isn't set. Contents of the github application certificate in `pkcs8` format as per the [App certificate](#app-certificate) section.
 
-**Reqiured**: true
+**Required**: true
 
 ### `GITHUB_APP_CERT_FILE`
 Mandatory when `GITHUB_APP_CERT` isn't set. Location of the file containing the github application certificate in `pkcs8` format as per the [App certificate](#app-certificate) section.
 
-**Reqiured**: true
+**Required**: true
 
 ### `GITHUB_API_ENDPOINT`
 The GitHub API endpoint in case it is a custom installation.
 
-**Reqiured**: false
+**Required**: false
 
 ### `SLACK_API_TOKEN`
 Mandatory when `SLACK_API_TOKEN_FILE` isn't set. Slack API token as per the [Slack](#slack) section.
 
-**Reqiured**: true
+**Required**: true
 
 ### `SLACK_API_TOKEN_FILE`
 Mandatory when `SLACK_API_TOKEN` isn't set. Location of the file containing the Slack API token as per the [Slack](#slack) section.
 
-**Reqiured**: true
+**Required**: true
 
 ### `JOBS_GITHUB_INSTALLATION_SCAN_INTERVAL`
 This is the interval in milliseconds between installation scans and consequently repository scans for configuration updates.
 
-**Reqiured**: false
+**Required**: false
 **Default**: 43200000
 
 ### `STATE_STORAGE_TYPE`
 Storage type, at this time it can be local file system, GCS Bucket implementation is coming soon.
 
-**Reqiured**: false
+**Required**: false
 **Default**: `LOCAL_FS`
 **Options:**
 - `LOCAL_FS`: Local file system
@@ -108,8 +108,20 @@ Storage type, at this time it can be local file system, GCS Bucket implementatio
 ### `STATE_STORAGE_FS_FILEPATH`
 When `LOCAL_FS` is used in `STATE_STORAGE_TYPE`, the application's state will be stored at this location.
 
-**Reqiured**: false
+**Required**: false
 **Default**: `/tmp/github-reminder-application.state.json`
+
+### ACTIVITY_TRACKING_ENABLED
+Enables tracking clicks on the links/buttons posted with the notifications.
+
+**Required**: false
+**Default**: `false`
+
+### ACTIVITY_TRACKING_ENDPOINT_URL
+The application has to know its own endpoint to build tracking urls that will forward users to the target urls.
+
+**Required**: false
+**Default**: `http://localhost:8080`
 
 ## Coming soon...
 | Name | Is Required? | Default value | Description |

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.bbaga</groupId>
 	<artifactId>github-scheduled-reminder-app</artifactId>
-	<version>0.5.0-SNAPSHOT</version>
+	<version>0.6.0-SNAPSHOT</version>
 	<name>github-scheduled-reminder-app</name>
 	<description>github-scheduled-reminder-app</description>
 	<properties>

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/Config.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/Config.java
@@ -3,6 +3,7 @@ package com.bbaga.githubscheduledreminderapp.application;
 import com.bbaga.githubscheduledreminderapp.domain.GitHubAppInstallationService;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.ConfigGraphNode;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.ConfigGraphUpdater;
+import com.bbaga.githubscheduledreminderapp.domain.statistics.AggregatedStatisticsStorage;
 import com.bbaga.githubscheduledreminderapp.infrastructure.configuration.InRepoConfigParser;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.RepositoryInstallationEventListener;
 import com.bbaga.githubscheduledreminderapp.infrastructure.configuration.persitance.ConfigPersistenceFactory;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/controllers/Redirect.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/controllers/Redirect.java
@@ -1,0 +1,21 @@
+package com.bbaga.githubscheduledreminderapp.application.controllers;
+
+import com.bbaga.githubscheduledreminderapp.domain.statistics.AggregatedStatisticsStorage;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+
+@RestController
+public class Redirect {
+
+    private final AggregatedStatisticsStorage statisticsStorage;
+
+    Redirect(AggregatedStatisticsStorage statisticsStorage) {
+        this.statisticsStorage = statisticsStorage;
+    }
+
+    @GetMapping("/redirect/action")
+    public RedirectView redirect(@RequestParam String source, @RequestParam String action, @RequestParam String targetUrl) {
+        statisticsStorage.increase(String.format("%s.%s", source, action));
+        return new RedirectView(targetUrl);
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/controllers/Statistics.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/controllers/Statistics.java
@@ -1,0 +1,31 @@
+package com.bbaga.githubscheduledreminderapp.application.controllers;
+
+import com.bbaga.githubscheduledreminderapp.domain.statistics.AggregatedStatisticsStorage;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@RestController
+public class Statistics {
+
+    private final AggregatedStatisticsStorage statisticsStorage;
+
+    Statistics(AggregatedStatisticsStorage statisticsStorage) {
+        this.statisticsStorage = statisticsStorage;
+    }
+
+    @GetMapping("/statistics/fetch")
+    public HashMap<String, AtomicLong> fetch() {
+        HashMap<String, AtomicLong> aggregates = new HashMap<>(statisticsStorage.getAggregates());
+        statisticsStorage.reset();
+        return aggregates;
+    }
+
+    @GetMapping("/statistics/show")
+    public ConcurrentHashMap<String, AtomicLong> show() {
+        return statisticsStorage.getAggregates();
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/AggregatedStatisticsStorage.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/AggregatedStatisticsStorage.java
@@ -1,0 +1,29 @@
+package com.bbaga.githubscheduledreminderapp.domain.statistics;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AggregatedStatisticsStorage {
+
+    private final ConcurrentHashMap<String, AtomicLong> aggregates = new ConcurrentHashMap<>();
+
+    public void increase(String name) {
+        if (!aggregates.containsKey(name)) {
+            aggregates.putIfAbsent(name, new AtomicLong(0));
+        }
+
+        aggregates.get(name).incrementAndGet();
+    }
+
+    public ConcurrentHashMap<String, AtomicLong> getAggregates() {
+        synchronized (aggregates) {
+            return aggregates;
+        }
+    }
+
+    public void reset () {
+        synchronized (aggregates) {
+            aggregates.clear();
+        }
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/PassThroughUrlBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/PassThroughUrlBuilder.java
@@ -1,0 +1,9 @@
+package com.bbaga.githubscheduledreminderapp.domain.statistics;
+
+import java.io.UnsupportedEncodingException;
+
+public class PassThroughUrlBuilder implements UrlBuilderInterface {
+    public String from(String source, String action, String targetUrl) throws UnsupportedEncodingException {
+        return targetUrl;
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/StatisticsConfig.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/StatisticsConfig.java
@@ -1,0 +1,29 @@
+package com.bbaga.githubscheduledreminderapp.domain.statistics;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StatisticsConfig {
+
+    @Value("${application.activityTracking.enabled}")
+    private Boolean activityTrackingEnabled = false;
+
+    @Value("${application.activityTracking.endpoint.url}")
+    private String activityTrackingEndpointUrl = "";
+
+    @Bean
+    public AggregatedStatisticsStorage getStatisticsAggregator() {
+        return new AggregatedStatisticsStorage();
+    }
+
+    @Bean
+    public UrlBuilderInterface getTrackingUrlBuilder() {
+        if (activityTrackingEnabled) {
+            return new TrackingUrlBuilder(this.activityTrackingEndpointUrl);
+        } else {
+            return new PassThroughUrlBuilder();
+        }
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/TrackingUrlBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/TrackingUrlBuilder.java
@@ -1,0 +1,24 @@
+package com.bbaga.githubscheduledreminderapp.domain.statistics;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class TrackingUrlBuilder implements UrlBuilderInterface {
+
+    private final String endpointUrl;
+
+    public TrackingUrlBuilder(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+    }
+
+    public String from(String source, String action, String targetUrl) throws UnsupportedEncodingException {
+        return String.format(
+                "%s/redirect/action?source=%s&action=%s&targetUrl=%s",
+                endpointUrl,
+                action,
+                source,
+                URLEncoder.encode(targetUrl, StandardCharsets.UTF_8.toString())
+        );
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/UrlBuilderInterface.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/UrlBuilderInterface.java
@@ -1,0 +1,7 @@
+package com.bbaga.githubscheduledreminderapp.domain.statistics;
+
+import java.io.UnsupportedEncodingException;
+
+public interface UrlBuilderInterface {
+    String from(String source, String action, String targetUrl) throws UnsupportedEncodingException;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,5 @@ application.state.storage.gcs_bucket.secret=${STATE_STORAGE_GCS_BUCKET_SECRET:}
 application.state.storage.gcs_bucket.secretFile=${STATE_STORAGE_GCS_BUCKET_SECRET_FILE:}
 application.state.storage.gcs_bucket.filepath=${STATE_STORAGE_GCS_BUCKET_FILEPATH:application.state.json}
 application.state.storage.fs.filepath=${STATE_STORAGE_FS_FILEPATH:/tmp/github-reminder-application.state.json}
+application.activityTracking.enabled=${ACTIVITY_TRACKING_ENABLED:false}
+application.activityTracking.endpoint.url=${ACTIVITY_TRACKING_ENDPOINT_URL:http://localhost:8080}

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
@@ -2,6 +2,7 @@ package com.bbaga.githubscheduledreminderapp.domain.notifications.slack;
 
 import com.bbaga.githubscheduledreminderapp.domain.configuration.Notification;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.SlackNotification;
+import com.bbaga.githubscheduledreminderapp.domain.statistics.UrlBuilderInterface;
 import com.hubspot.algebra.Result;
 import com.hubspot.slack.client.SlackClient;
 import com.hubspot.slack.client.methods.params.chat.ChatPostMessageParams;
@@ -33,12 +34,13 @@ class ChannelNotificationTest {
     @Test
     void sendCalledWithEmptySets() {
         SlackClient client = Mockito.mock(SlackClient.class);
+        UrlBuilderInterface urlBuilder = Mockito.mock(UrlBuilderInterface.class);
         //noinspection unchecked
         Result<ChatPostMessageResponse, SlackError> result = (Result<ChatPostMessageResponse, SlackError>) Mockito.mock(Result.class);
         CompletableFuture<Result<ChatPostMessageResponse, SlackError>> future = new CompletableFuture<>();
         future.complete(result);
 
-        ChannelNotification service = new ChannelNotification(client);
+        ChannelNotification service = new ChannelNotification(client, urlBuilder);
         SlackNotification config = new SlackNotification();
         config.setChannel("test");
         Notification notification = new Notification();
@@ -54,6 +56,7 @@ class ChannelNotificationTest {
     @Test
     void sendCalled() throws IOException {
         SlackClient client = Mockito.mock(SlackClient.class);
+        UrlBuilderInterface urlBuilder = Mockito.mock(UrlBuilderInterface.class);
         GHIssue issue = Mockito.mock(GHIssue.class);
         GHUser user = Mockito.mock(GHUser.class);
         GHRepository repository = Mockito.mock(GHRepository.class);
@@ -81,7 +84,7 @@ class ChannelNotificationTest {
         CompletableFuture<Result<ChatPostMessageResponse, SlackError>> future = new CompletableFuture<>();
         future.complete(result);
 
-        ChannelNotification service = new ChannelNotification(client);
+        ChannelNotification service = new ChannelNotification(client, urlBuilder);
         SlackNotification config = new SlackNotification();
         config.setChannel("test");
         Notification notification = new Notification();


### PR DESCRIPTION
Adding tracking endpoint and tracking url building.

## New configuration values:
### ACTIVITY_TRACKING_ENABLED
Enables tracking clicks on the links/buttons posted with the notifications.

**Required**: false
**Default**: `false`

### ACTIVITY_TRACKING_ENDPOINT_URL
The application has to know its own endpoint to build tracking urls that will forward users to the target urls.

**Required**: false
**Default**: `http://localhost:8080`

## New HTTP endpoints
### Tracking/Redirect URL
`/redirect/action` - expects three query parameters: `source`, `action` and `targetUrl`

### Tracking Statistics
`/statistics/show` - returns a json object with the collected statistics.

`/statistics/fetch` - returns a json object with the collected statistics then resets the metrics.
