### PR TITLE
Make single-config file approach an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,9 @@ notifications:
     type: slack/channel
     config:
       channel: "test-channel"
-  
-  - extending: 
-      repository: bbaga/app-testing
-      name: slack-notification
+    repositories:
+       bbaga/app-testing:
+         sources: ... # Sources config is optional. See more at docs/sources.md 
 ```
 
 | Field | Is Required? | Description |
@@ -164,6 +163,7 @@ notifications:
 | `timezone` | No | Timezone to adjust the schedule to. Defaults to `UTC`. |
 | `type` | Yes | The only supported `type` is `slack/channel`. |
 | `config` | No | Depends on the `type` field's value, each notification type may have different configuration. |
+| `repositories` | No | Map of repositories to configuration values. |
 
 ### References
 | Field | Is Required? | Description |

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/Config.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/Config.java
@@ -205,9 +205,10 @@ public class Config {
     @Bean
     public ConfigGraphUpdater getConfigGraphUpdater(
         @Qualifier("ConfigGraph") ConcurrentHashMap<String, ConfigGraphNode> configGraph,
-        NotificationJobScheduler notificationJobScheduler
+        NotificationJobScheduler notificationJobScheduler,
+        GitHubInstallationRepository installationRepository
     ) {
-        return new ConfigGraphUpdater(configGraph, notificationJobScheduler);
+        return new ConfigGraphUpdater(installationRepository, configGraph, notificationJobScheduler);
     }
 
     @Bean

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/jobs/GitHubInstallationScan.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/jobs/GitHubInstallationScan.java
@@ -3,6 +3,7 @@ package com.bbaga.githubscheduledreminderapp.application.jobs;
 import com.bbaga.githubscheduledreminderapp.domain.jobs.scheduling.InstallationScanJobScheduler;
 import com.bbaga.githubscheduledreminderapp.infrastructure.github.repositories.GitHubInstallationRepository;
 import org.kohsuke.github.GHAppInstallation;
+import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.PagedIterable;
 import org.quartz.*;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Extending.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Extending.java
@@ -14,6 +14,11 @@ public class Extending implements NotificationInterface {
 
     public Extending() {}
 
+    public Extending(MainConfig mainConfig, NotificationConfigurationInterface config) {
+        this.setExtending(mainConfig);
+        this.setConfig(config);
+    }
+
     public MainConfig getExtending() {
         return extending;
     }
@@ -37,6 +42,11 @@ public class Extending implements NotificationInterface {
         private String name = "";
 
         public MainConfig() {}
+
+        public MainConfig(String repository, String name) {
+            this.setRepository(repository);
+            this.setName(name);
+        }
 
         public String getRepository() {
             return repository;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Notification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/Notification.java
@@ -5,13 +5,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Map;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Notification implements NotificationInterface {
+    private String repository = "";
     private String name = "";
     private String schedule;
     private String type = "";
+    private Map<String, NotificationConfiguration> repositories;
 
     @JsonSubTypes({
         @JsonSubTypes.Type(value = SlackNotification.class, name = "slack/channel"),
@@ -36,12 +39,24 @@ public class Notification implements NotificationInterface {
         this.config = config;
     }
 
+    public String getRepository() {
+        return repository;
+    }
+
+    public void setRepository(String repository) {
+        this.repository = repository;
+    }
+
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    public String getFullName() {
+        return getRepository() + "-" + getName();
     }
 
     public Optional<String> getSchedule() {
@@ -76,5 +91,13 @@ public class Notification implements NotificationInterface {
 
     public void setTimeZone(String timeZone) {
         this.timeZone = timeZone;
+    }
+
+    public Map<String, NotificationConfiguration> getRepositories() {
+        return repositories;
+    }
+
+    public void setRepositories(Map<String, NotificationConfiguration> repositories) {
+        this.repositories = repositories;
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobScheduler.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobScheduler.java
@@ -21,7 +21,7 @@ public class NotificationJobScheduler {
             return;
         }
 
-        JobKey jobKey = new JobKey(notification.getName());
+        JobKey jobKey = new JobKey(notification.getRepository());
 
         if (scheduler.checkExists(jobKey)) {
             updateSchedule(notification);
@@ -37,7 +37,7 @@ public class NotificationJobScheduler {
             return;
         }
 
-        JobKey jobKey = new JobKey(notification.getName());
+        JobKey jobKey = new JobKey(notification.getRepository());
 
         JobDetail job = JobBuilder.newJob(ScheduledNotification.class)
             .withIdentity(jobKey)
@@ -64,7 +64,7 @@ public class NotificationJobScheduler {
 
         Trigger newTrigger = TriggerBuilder.newTrigger()
             .withSchedule(CronScheduleBuilder.cronSchedule(schedule.get()).inTimeZone(timeZone))
-            .withIdentity(notification.getName()).build();
-        scheduler.rescheduleJob(new TriggerKey(notification.getName()), newTrigger);
+            .withIdentity(notification.getRepository()).build();
+        scheduler.rescheduleJob(new TriggerKey(notification.getRepository()), newTrigger);
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -80,7 +80,7 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
             }
         }
 
-        sections.add(markdownSection("config id: _%s_", notification.getName()));
+        sections.add(markdownSection("config id: _%s_", notification.getRepository()));
 
         slackClient.postMessage(
             ChatPostMessageParams.builder()

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/AppInstallationContainer.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/AppInstallationContainer.java
@@ -1,6 +1,7 @@
 package com.bbaga.githubscheduledreminderapp.infrastructure.github;
 
 import org.kohsuke.github.GHAppInstallation;
+import org.kohsuke.github.GHUser;
 
 public class AppInstallationContainer {
     private final GHAppInstallation installation;
@@ -10,6 +11,10 @@ public class AppInstallationContainer {
 
     public long getId() {
         return installation.getId();
+    }
+
+    public GHUser getAccount() {
+        return installation.getAccount();
     }
 
     public GHAppInstallation unwrap() {

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepository.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepository.java
@@ -8,16 +8,21 @@ import java.util.Set;
 
 public class GitHubInstallationRepository {
     private final HashMap<Long, AppInstallationContainer> installations = new HashMap<>();
+    private final HashMap<String, Long> mapOrgToInstallation = new HashMap<>();
 
     public void put(GHAppInstallation installation) {
         AppInstallationContainer container = AppInstallationContainer.create(installation);
         synchronized (this.installations) {
             installations.put(container.getId(), container);
+            mapOrgToInstallation.putIfAbsent(container.getAccount().getLogin(), container.getId());
         }
     }
 
     public void remove(Long installationId) {
         synchronized (this.installations) {
+            AppInstallationContainer container = installations.get(installationId);
+            String key = container.getAccount().getLogin();
+            mapOrgToInstallation.remove(key);
             installations.remove(installationId);
         }
     }
@@ -31,6 +36,12 @@ public class GitHubInstallationRepository {
             }
 
             return container.unwrap();
+        }
+    }
+
+    public Long getIdByOrg(String org) {
+        synchronized (this.installations) {
+            return mapOrgToInstallation.get(org);
         }
     }
 

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/ConfigGraphUpdaterTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/ConfigGraphUpdaterTest.java
@@ -1,6 +1,7 @@
 package com.bbaga.githubscheduledreminderapp.domain.configuration;
 
 import com.bbaga.githubscheduledreminderapp.domain.jobs.scheduling.NotificationJobScheduler;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.repositories.GitHubInstallationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -16,9 +17,10 @@ class ConfigGraphUpdaterTest {
 
     @Test
     void updateEntry() throws SchedulerException {
+        GitHubInstallationRepository installationRepository = Mockito.mock(GitHubInstallationRepository.class);
         ConcurrentHashMap<String, ConfigGraphNode> configGraph = new ConcurrentHashMap<>();
         NotificationJobScheduler jobScheduler = Mockito.mock(NotificationJobScheduler.class);
-        ConfigGraphUpdater configUpdater = new ConfigGraphUpdater(configGraph, jobScheduler);
+        ConfigGraphUpdater configUpdater = new ConfigGraphUpdater(installationRepository, configGraph, jobScheduler);
 
         Notification notification = new Notification("name", "* * * * * *", "type", new NotificationConfiguration());
 
@@ -34,11 +36,13 @@ class ConfigGraphUpdaterTest {
 
     @Test
     void updateEntryWithBufferUsage() throws SchedulerException {
+        GitHubInstallationRepository installationRepository = Mockito.mock(GitHubInstallationRepository.class);
         ConcurrentHashMap<String, ConfigGraphNode> configGraph = new ConcurrentHashMap<>();
         NotificationJobScheduler jobScheduler = Mockito.mock(NotificationJobScheduler.class);
-        ConfigGraphUpdater configUpdater = new ConfigGraphUpdater(configGraph, jobScheduler);
+        ConfigGraphUpdater configUpdater = new ConfigGraphUpdater(installationRepository, configGraph, jobScheduler);
 
         Notification notification = new Notification("name", "* * * * * *", "type", new NotificationConfiguration());
+        notification.setRepository("some/repo");
         Extending.MainConfig extendingConfig = new Extending.MainConfig();
         extendingConfig.setRepository("some/repo");
         extendingConfig.setName("name");

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/NotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/NotificationTest.java
@@ -19,9 +19,10 @@ class NotificationTest {
     @Test
     void setName() {
         final String name = "notification-name";
-        notification.setName(name);
+        notification.setRepository("notification");
+        notification.setName("name");
 
-        assertEquals(name, notification.getName());
+        assertEquals(name, notification.getFullName());
     }
 
     @Test

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobSchedulerTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/jobs/scheduling/NotificationJobSchedulerTest.java
@@ -1,7 +1,6 @@
 package com.bbaga.githubscheduledreminderapp.domain.jobs.scheduling;
 
 import com.bbaga.githubscheduledreminderapp.domain.configuration.Notification;
-import com.bbaga.githubscheduledreminderapp.domain.jobs.scheduling.NotificationJobScheduler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
@@ -23,7 +22,8 @@ class NotificationJobSchedulerTest {
     @Test
     void createSchedule() throws SchedulerException {
         Notification notification = new Notification();
-        notification.setName("test-schedule");
+        notification.setRepository("test");
+        notification.setName("schedule");
         notification.setSchedule("* * * * * ?");
         notification.setTimeZone("Europe/Berlin");
 
@@ -38,8 +38,8 @@ class NotificationJobSchedulerTest {
         JobDetail capturedJobDetail = jobDetailCaptor.getValue();
         CronTrigger capturedTrigger = triggerCaptor.getValue();
 
-        assertEquals(notification.getName(), capturedJobDetail.getKey().getName());
-        assertEquals(notification.getName(), capturedTrigger.getKey().getName());
+        assertEquals(notification.getRepository(), capturedJobDetail.getKey().getName());
+        assertEquals(notification.getRepository(), capturedTrigger.getKey().getName());
         assertEquals(notification.getSchedule().get(), capturedTrigger.getCronExpression());
         assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
     }
@@ -47,7 +47,8 @@ class NotificationJobSchedulerTest {
     @Test
     void updateSchedule() throws SchedulerException {
         Notification notification = new Notification();
-        notification.setName("test-schedule");
+        notification.setRepository("test");
+        notification.setName("schedule");
         notification.setSchedule("* * * * * ?");
         notification.setTimeZone("Europe/Berlin");
 
@@ -62,7 +63,7 @@ class NotificationJobSchedulerTest {
         TriggerKey capturedTriggerKey = triggerKeyCaptor.getValue();
         CronTrigger capturedTrigger = triggerCaptor.getValue();
 
-        assertEquals(notification.getName(), capturedTriggerKey.getName());
+        assertEquals(notification.getRepository(), capturedTriggerKey.getName());
         assertEquals(notification.getSchedule().get(), capturedTrigger.getCronExpression());
         assertEquals(TimeZone.getTimeZone(notification.getTimeZone()), capturedTrigger.getTimeZone());
     }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepositoryTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHAppInstallation;
+import org.kohsuke.github.GHUser;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +29,7 @@ class GitHubInstallationRepositoryTest {
     void remove() {
         long id = 123456L;
         GHAppInstallation installation = Mockito.mock(GHAppInstallation.class);
+        GHUser account = Mockito.mock(GHUser.class);
         AppInstallationContainer installationContainer = Mockito.mock(AppInstallationContainer.class);
 
         MockedStatic<AppInstallationContainer> provider = Mockito.mockStatic(AppInstallationContainer.class);
@@ -35,9 +37,11 @@ class GitHubInstallationRepositoryTest {
                 .thenReturn(installationContainer);
 
         Mockito.doReturn(id).when(installationContainer).getId();
+        Mockito.doReturn(account).when(installationContainer).getAccount();
+        Mockito.doReturn("bbaga").when(account).getLogin();
         Mockito.doReturn(installation).when(installationContainer).unwrap();
         this.repository.put(installation);
-        Mockito.verify(installationContainer, Mockito.times(1)).getId();
+        Mockito.verify(installationContainer, Mockito.times(2)).getId();
 
         assertSame(installation, this.repository.get(id));
         this.repository.remove(id);
@@ -50,6 +54,7 @@ class GitHubInstallationRepositoryTest {
 
         for (long id : ids) {
             GHAppInstallation installation = Mockito.mock(GHAppInstallation.class);
+            GHUser account = Mockito.mock(GHUser.class);
             AppInstallationContainer installationContainer = Mockito.mock(AppInstallationContainer.class);
 
             MockedStatic<AppInstallationContainer> provider = Mockito.mockStatic(AppInstallationContainer.class);
@@ -57,6 +62,8 @@ class GitHubInstallationRepositoryTest {
                     .thenReturn(installationContainer);
 
             Mockito.doReturn(id).when(installationContainer).getId();
+            Mockito.doReturn(account).when(installationContainer).getAccount();
+            Mockito.doReturn("bbaga").when(account).getLogin();
             this.repository.put(installation);
             provider.close();
         }


### PR DESCRIPTION
Creating configuration in repositories that aren't owned by a specific team, but the application is installed is easier if we can place the configuration in any other repository. Since the application is installed for a repository, it should be able to read the necessary data.

Configuring watch for third party repositories:
```yaml
enabled: true
notifications:
  - name: slack-notification
    schedule: "*/30 * * * * ?"
    timezone: "EST"
    type: slack/channel
    config:
      channel: "test-channel"
    repositories:
       third-party/repo-a:
       third-party/repo-b:
       my-own/repo:
```