### PR TITLE
Improve statistics granularity

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -127,6 +127,16 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
             mergeableEmoji = ":large_yellow_circle:";
         }
 
+        logger.debug(
+            String.format(
+                "[PR] %s; mergeable-state: %s; created-at: %s; updated-at: %s",
+                pullRequest.getHtmlUrl(),
+                mergeableState,
+                pullRequest.getCreatedAt(),
+                pullRequest.getUpdatedAt()
+            )
+        );
+
         return markdownSection(
             "%s %s *%s*%nrepository: %s, age: %s, :heavy_minus_sign: %d :heavy_plus_sign: %d",
             mergeableEmoji,
@@ -140,6 +150,14 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
     }
 
     private Block getSection(GitHubIssue issue) throws IOException {
+        logger.debug(
+                String.format(
+                        "[Issue] %s; created-at: %s; updated-at: %s",
+                        issue.getHtmlUrl(),
+                        issue.getCreatedAt(),
+                        issue.getUpdatedAt()
+                )
+        );
 
         return markdownSection(
             "%s *%s*%nrepository: %s, age: %s",
@@ -173,15 +191,13 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
     }
 
     private Button linkButton(GitHubIssue issue) {
-        String action = (issue instanceof GitHubPullRequest ? "pull-request" : "issue") + ".view";
-        String targetUrl = issue.getHtmlUrl().toString();
         String url;
 
         try {
-            url = urlBuilder.from("slack.channel", action, targetUrl);
+            url = urlBuilder.from("slack.channel", issue);
         } catch (UnsupportedEncodingException e) {
             logger.error(e.getMessage(), e);
-            url = targetUrl;
+            url = issue.getHtmlUrl().toString();
         }
 
         return Button.of(Text.of(TextType.PLAIN_TEXT, "Open"), issue.getNodeId()).withUrl(url);

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/PassThroughUrlBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/PassThroughUrlBuilder.java
@@ -1,9 +1,11 @@
 package com.bbaga.githubscheduledreminderapp.domain.statistics;
 
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
+
 import java.io.UnsupportedEncodingException;
 
 public class PassThroughUrlBuilder implements UrlBuilderInterface {
-    public String from(String source, String action, String targetUrl) throws UnsupportedEncodingException {
-        return targetUrl;
+    public String from(String source, GitHubIssue issue) throws UnsupportedEncodingException {
+        return issue.getHtmlUrl().toString();
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/TrackingUrlBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/TrackingUrlBuilder.java
@@ -1,5 +1,8 @@
 package com.bbaga.githubscheduledreminderapp.domain.statistics;
 
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubPullRequest;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -12,12 +15,16 @@ public class TrackingUrlBuilder implements UrlBuilderInterface {
         this.endpointUrl = endpointUrl;
     }
 
-    public String from(String source, String action, String targetUrl) throws UnsupportedEncodingException {
+    public String from(String source, GitHubIssue issue) throws UnsupportedEncodingException {
+        String action = (issue instanceof GitHubPullRequest ? "pull-request" : "issue") + ".view";
+        action += String.format(".%s.%s", issue.getRepository().getFullName(), issue.getNumber());
+        String targetUrl = issue.getHtmlUrl().toString();
+
         return String.format(
                 "%s/redirect/action?source=%s&action=%s&targetUrl=%s",
                 endpointUrl,
-                action,
                 source,
+                URLEncoder.encode(action, StandardCharsets.UTF_8.toString()),
                 URLEncoder.encode(targetUrl, StandardCharsets.UTF_8.toString())
         );
     }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/UrlBuilderInterface.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/statistics/UrlBuilderInterface.java
@@ -1,7 +1,9 @@
 package com.bbaga.githubscheduledreminderapp.domain.statistics;
 
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
+
 import java.io.UnsupportedEncodingException;
 
 public interface UrlBuilderInterface {
-    String from(String source, String action, String targetUrl) throws UnsupportedEncodingException;
+    String from(String source, GitHubIssue issue) throws UnsupportedEncodingException;
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
@@ -15,6 +15,10 @@ public class GitHubPullRequest extends GitHubIssue {
         return pullRequest.getMergeableState();
     }
 
+    public Boolean getMergeable() throws IOException {
+        return pullRequest.getMergeable();
+    }
+
     public int getAdditions() throws IOException {
         return pullRequest.getAdditions();
     }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
@@ -131,7 +131,7 @@ class ChannelNotificationTest {
         Mockito.verify(issue, Mockito.times(1)).getTitle();
         Mockito.verify(issue, Mockito.times(1)).getUser();
         Mockito.verify(issue, Mockito.times(1)).getRepository();
-        Mockito.verify(issue, Mockito.times(1)).getCreatedAt();
+        Mockito.verify(issue, Mockito.times(2)).getCreatedAt();
 
     }
 }

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotificationTest.java
@@ -125,7 +125,7 @@ class ChannelNotificationTest {
         Mockito.verify(pr, Mockito.times(1)).getTitle();
         Mockito.verify(pr, Mockito.times(1)).getUser();
         Mockito.verify(pr, Mockito.times(1)).getRepository();
-        Mockito.verify(pr, Mockito.times(1)).getCreatedAt();
+        Mockito.verify(pr, Mockito.times(2)).getCreatedAt();
 
         // Verify Issue methods
         Mockito.verify(issue, Mockito.times(1)).getTitle();


### PR DESCRIPTION
Improve statistics granularity to include more information on the repositories and Issue/Pr ids.

New format example:
```
slack.channel.issue.view.bbaga/github-scheduled-reminder-app.44: 2
slack.channel.pull-request.view.bbaga/app-testing.1: 1
slack.channel.pull-request.view.bbaga/app-testing.2: 3
```

Closes #44 