### PR TITLE
Correct placeholder replacement in the overflow message

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelMessageBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelMessageBuilder.java
@@ -38,7 +38,7 @@ public class ChannelMessageBuilder implements ChannelMessageBuilderInterface {
 
         if (showing < from) {
             counter = overflowFormat.replaceAll("\\$showing", String.valueOf(showing))
-                                .replaceAll("\\$from", String.valueOf(showing));
+                                .replaceAll("\\$from", String.valueOf(from));
         } else {
             counter = String.valueOf(showing);
         }


### PR DESCRIPTION
As the title says, correcting placeholder replacement in the overflow message