### PR TITLE
Add rate limit stats to metrics

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepository.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/repositories/GitHubInstallationRepository.java
@@ -50,4 +50,10 @@ public class GitHubInstallationRepository {
             return installations.keySet();
         }
     }
+
+    public Set<String> getOrgs() {
+        synchronized (this.installations) {
+            return mapOrgToInstallation.keySet();
+        }
+    }
 }

--- a/src/main/java/org/kohsuke/github/GitHubClientUtil.java
+++ b/src/main/java/org/kohsuke/github/GitHubClientUtil.java
@@ -2,10 +2,16 @@ package org.kohsuke.github;
 
 import org.kohsuke.github.internal.Previews;
 
+import java.io.IOException;
+
 public class GitHubClientUtil {
     public static PagedSearchIterable<GHRepository> listRepositories(GitHub gitHub) {
         GitHubRequest request = ((Requester)((Requester)gitHub.createRequest().withPreview(Previews.MACHINE_MAN)).withUrlPath("/installation/repositories", new String[0])).build();
         return new PagedSearchIterable(gitHub, request, GHAppInstallationRepositoryResult.class);
+    }
+
+    public static GHRateLimit getRateLimit(GitHub gitHub) throws IOException {
+        return gitHub.getClient().getRateLimit();
     }
 
     private static class GHAppInstallationRepositoryResult extends SearchResult<GHRepository> {


### PR DESCRIPTION
Add rate limit stats to metrics:

```json
{
  "github.app.installation.my-org.rate-limit.core.limit": 5050,
  "github.app.installation.my-org.rate-limit.core.remaining": 5050,
  "github.app.installation.my-org.rate-limit.graphql.limit": 5050,
  "github.app.installation.my-org.rate-limit.graphql.remaining": 5050,
  "github.app.installation.my-org.rate-limit.integration-manifest.limit": 5000,
  "github.app.installation.my-org.rate-limit.integration-manifest.remaining": 5000,
  "github.app.installation.my-org.rate-limit.search.limit": 30,
  "github.app.installation.my-org.rate-limit.search.remaining": 30
}
```