### PR TITLE
Adjust clearing outdated configs across multiple installations

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/configGraphUpdater/ConfigGraphUpdater.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/configGraphUpdater/ConfigGraphUpdater.java
@@ -85,7 +85,7 @@ public class ConfigGraphUpdater {
         addBuffered(notification);
     }
 
-    public void clearOutdated(Long installationId, Instant timestamp) {
+    public void  clearOutdated(Long installationId, Instant timestamp) {
         configGraph.entrySet().removeIf(entry -> {
             ConfigGraphNode node = entry.getValue();
             if (node.getInstallationId().equals(installationId) && node.getLastSeenAt() != timestamp) {
@@ -94,8 +94,17 @@ public class ConfigGraphUpdater {
 
             node.getRepositories().entrySet().removeIf(repoEntry -> {
                 RepositoryRecord repositoryRecord = repoEntry.getValue();
-                return repositoryRecord.getInstallationId().equals(installationId)
-                        && repositoryRecord.getSeenAt() != timestamp;
+
+                NotificationConfigurationInterface notificationConfig = node.getNotification().getConfig();
+
+                if (repositoryRecord.getSeenAt() != timestamp) {
+                    boolean isLocalConfig = notificationConfig instanceof RepositoryAwareNotificationConfiguration
+                        && ((RepositoryAwareNotificationConfiguration) notificationConfig).getRepositories().containsKey(repositoryRecord.getRepository());
+
+                    return repositoryRecord.getInstallationId().equals(installationId) && !isLocalConfig;
+                }
+
+                return false;
             });
 
             return false;

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/ConfigGraphUpdaterTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/configuration/ConfigGraphUpdaterTest.java
@@ -3,6 +3,8 @@ package com.bbaga.githubscheduledreminderapp.domain.configuration;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.configGraphUpdater.*;
 import com.bbaga.githubscheduledreminderapp.domain.jobs.scheduling.NotificationJobScheduler;
 import com.bbaga.githubscheduledreminderapp.infrastructure.github.repositories.GitHubInstallationRepository;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.quartz.SchedulerException;
@@ -71,10 +73,113 @@ class ConfigGraphUpdaterTest {
 
     @Test
     void clearOutdated() {
+        Instant instantA = Instant.now();
+        Instant instantB = Instant.now().minusSeconds(5);
+
+        /**
+         * Test subject for repositories from different installations, but both defined locally
+         * Expected to have both repositories in the notification after clearing
+         */
+        ConfigGraphNode nodeA = nodeBuilder(
+            "A",
+            1,
+            instantA,
+            Map.of(
+                "same-installation-id", new NotificationConfiguration(),
+                "not-the-same-installation-id", new NotificationConfiguration()
+            ),
+            List.of(
+                new RepositoryRecord("same-installation-id", 1L, instantA, new NotificationConfiguration()),
+                new RepositoryRecord("not-the-same-installation-id", 2L, instantA, new NotificationConfiguration())
+            )
+        );
+
+        /**
+         * Test subject for repositories from different installations, but only one is defined locally
+         * Expected to lose the repository that isn't defined locally
+         */
+        ConfigGraphNode nodeB = nodeBuilder(
+            "B",
+            1,
+            instantA,
+            Map.of(
+                "same-installation-id", new NotificationConfiguration()
+            ),
+            List.of(
+                new RepositoryRecord("same-installation-id", 1L, instantA, new NotificationConfiguration()),
+                new RepositoryRecord("not-the-same-installation-id", 2L, instantA, new NotificationConfiguration())
+            )
+        );
+
+        /**
+         * Test subject for notification with wrong timestamp
+         * Expected to lose the whole notification
+         */
+        ConfigGraphNode nodeC = nodeBuilder(
+            "C",
+            1,
+            instantB,
+            Map.of(
+                "same-installation-id", new NotificationConfiguration()
+            ),
+            List.of(
+                new RepositoryRecord("same-installation-id", 1L, instantA, new NotificationConfiguration()),
+                new RepositoryRecord("not-the-same-installation-id", 2L, instantA, new NotificationConfiguration())
+            )
+        );
+
+        /**
+         * Test subject for repositories from different installations, none of them is defined locally
+         * Expected to lose repositories:
+         *  - not-the-same-installation-id-matching-ts, due to installation run TS and last seen TS mismatch
+         *  - same-installation-id-wrong-ts, due to installation run TS and last seen TS mismatch
+         */
+        ConfigGraphNode nodeD = nodeBuilder(
+            "D",
+            2,
+            instantB,
+            Map.of(),
+            List.of(
+                new RepositoryRecord("same-installation-id-wrong-ts", 2L, instantA, new NotificationConfiguration()),
+                new RepositoryRecord("same-installation-id-matching-ts", 2L, instantB, new NotificationConfiguration()),
+                new RepositoryRecord("not-the-same-installation-id-wrong-ts", 1L, instantA, new NotificationConfiguration()),
+                new RepositoryRecord("not-the-same-installation-id-matching-ts", 1L, instantB, new NotificationConfiguration())
+            )
+        );
+
+        ConcurrentHashMap<String, ConfigGraphNode> configGraph = new ConcurrentHashMap<>();
+        configGraph.put("A", nodeA);
+        configGraph.put("B", nodeB);
+        configGraph.put("C", nodeC);
+        configGraph.put("D", nodeD);
+
+        GitHubInstallationRepository installationRepository = Mockito.mock(GitHubInstallationRepository.class);
+        NotificationJobScheduler jobScheduler = Mockito.mock(NotificationJobScheduler.class);
+        ConfigVisitorFactoryFactory configVisitorFactoryFactory = new ConfigVisitorFactoryFactory(installationRepository);
+        ConfigGraphUpdater configUpdater = new ConfigGraphUpdater(configVisitorFactoryFactory, configGraph, jobScheduler);
+        configUpdater.clearOutdated(1L, instantA);
+        configUpdater.clearOutdated(2L, instantB);
+
+        assertEquals(3, configGraph.size());
+        assertEquals(2, configGraph.get("A").getRepositories().size());
+        assertEquals(1, configGraph.get("B").getRepositories().size());
+        assertEquals(2, configGraph.get("D").getRepositories().size());
     }
 
-    @Test
-    void testClearOutdated() {
+    private ConfigGraphNode nodeBuilder(
+        String name,
+        long installation,
+        Instant instant,
+        Map<String, NotificationConfigurationInterface> repoConfig,
+        List<RepositoryRecord> repoRecords
+    ) {
+        SlackNotificationConfiguration slackNotificationConfiguration = new SlackNotificationConfiguration();
+        slackNotificationConfiguration.setRepositories(repoConfig);
+        Notification notification = new Notification(name, "slack/scheduled/channel", slackNotificationConfiguration);
+        ConfigGraphNode node = new ConfigGraphNode(installation, notification, instant);
+        repoRecords.forEach(node::putRepository);
+
+        return node;
     }
 
     @Test


### PR DESCRIPTION
It was observed that configurations can be lost when a notification schedule has to monitor repositories from different installations. The likely cause is concurrency/timing conflict between the scheduled jobs responsible for keeping the internal state up to date. These jobs are scheduled to run approximately the same time in parallel for each installation ID and they remove outdated configuration settings based on the installation IDs and  the last seen time stamps.

The hypotheses is that the introduction of configuring the repositories as part of the schedules instead of extending schedule configurations from external files opened up the possibility for the last seen values to be different than the aforementioned scheduled update jobs would expect.

As an attempt to fix this issue, the clean up method will check whether the repositories are part of (or local to) schedule configuration in which case their last seen value will be less important.