### PR TITLE
Add option to skip the slack message when there are no issues or PRs

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/template/TemplateConfig.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/template/TemplateConfig.java
@@ -27,6 +27,9 @@ public class TemplateConfig {
     @JsonProperty("no-results")
     private String noResults = null;
 
+    @JsonProperty("skip-no-results")
+    private Boolean skipNoResults = null;
+
     @JsonProperty("overflow-format")
     private String overflowFormat = null;
 
@@ -78,6 +81,14 @@ public class TemplateConfig {
 
     public void setNoResults(String noResults) {
         this.noResults = noResults;
+    }
+
+    public Boolean getSkipNoResults() {
+        return skipNoResults;
+    }
+
+    public void setSkipNoResults(Boolean skipNoResults) {
+        this.skipNoResults = skipNoResults;
     }
 
     public String getOverflowFormat() {

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -72,6 +72,10 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
             templateConfig.setNoResults("*There aren't any open issues or pull requests.*");
         }
 
+        if (templateConfig.getSkipNoResults() == null) {
+            templateConfig.setSkipNoResults(false);
+        }
+
         if (templateConfig.getLineIssues() == null) {
             templateConfig.setLineIssues("$login *$title*\nrepository: $repository, age: $age$button");
         }
@@ -108,6 +112,10 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
         int prSectionsSize = prSections.size();
 
         if ((issueSectionsSize + prSectionsSize) == 0) {
+            if (templateConfig.getSkipNoResults().equals(true)) {
+                return;
+            }
+
             sections.add(messageBuilder.createNoResultsMessage(templateConfig.getNoResults()));
         } else {
             if (issueSectionsSize > 0) {


### PR DESCRIPTION
Adding new option to the `template-config` section to skip empty notifications.

| Field | Type | Default|
|---|---|---|
| `skip-no-results` |  `Boolean` | `false` |