### PR TITLE
Add anchor support in config YAML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.bbaga</groupId>
 	<artifactId>github-scheduled-reminder-app</artifactId>
-	<version>0.9.0-SNAPSHOT</version>
+	<version>0.10.0-SNAPSHOT</version>
 	<name>github-scheduled-reminder-app</name>
 	<description>github-scheduled-reminder-app</description>
 	<properties>

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfig.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfig.java
@@ -1,12 +1,14 @@
 package com.bbaga.githubscheduledreminderapp.infrastructure.configuration;
 
 import com.bbaga.githubscheduledreminderapp.domain.configuration.*;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class InRepoConfig {
     private Boolean enabled;
     private List<NotificationInterface> notifications = new ArrayList<>();

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfigParser.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/configuration/InRepoConfigParser.java
@@ -6,6 +6,7 @@ import org.kohsuke.github.GHRepository;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.yaml.snakeyaml.Yaml;
 
 public class InRepoConfigParser {
     private final ObjectMapper mapper;
@@ -18,6 +19,11 @@ public class InRepoConfigParser {
 
     public InRepoConfig getFrom(GHRepository repository) throws IOException {
         GHContent content = repository.getFileContent(configFilePath);
-        return mapper.readValue(new String(content.read().readAllBytes(), StandardCharsets.UTF_8), InRepoConfig.class);
+
+        // Trickery because Jackson doesn't handle YAML anchors
+        Object tmpYaml = new Yaml().loadAs(content.read(), Object.class);
+        String prettyYaml = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(tmpYaml);
+
+        return mapper.readValue(prettyYaml, InRepoConfig.class);
     }
 }


### PR DESCRIPTION
Jackson doesn't seem to handle anchors in YAML files still, so we have to make some hackery happen.

First we read and parse the YAML file with snakeyaml, then dump it back to "pretty" YAML where the anchors are resolved already. After this we read and parse the said pretty YAML with Jackson to get the fancy stuff going.

This is just terrible. Please send help.