### PR TITLE
Configuration should work without global sources defined

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/application/jobs/GitHubInstallationScan.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/application/jobs/GitHubInstallationScan.java
@@ -36,7 +36,7 @@ public class GitHubInstallationScan implements Job {
         this.jobScheduler = jobScheduler;
     }
 
-    public void execute(JobExecutionContext context) throws JobExecutionException {
+    public void execute(JobExecutionContext context) {
 
         logger.info("Starting Installation Scan");
         PagedIterable<GHAppInstallation> list = null;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -44,7 +44,7 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
     @Override
     public void send(ChannelNotificationDataProvider.Data data) {
         Notification notification = data.getNotification();
-        ArrayList<GitHubIssue> issues = data.getIssues();
+        List<GitHubIssue> issues = data.getIssues();
         TemplateConfig templateConfig = null;
 
         NotificationConfigurationInterface config = notification.getConfig();

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchAsSourceInterface.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchAsSourceInterface.java
@@ -1,13 +1,12 @@
 package com.bbaga.githubscheduledreminderapp.domain.sources.github;
 
 import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.SourceConfig;
+import java.util.List;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
-
 import java.io.IOException;
-import java.util.ArrayList;
 
 public interface SearchAsSourceInterface<T> {
     void configure(SourceConfig sourceConfig);
-    ArrayList<T> get(GHRepository repo, GitHub client) throws IOException;
+    List<T> get(GHRepository repo, GitHub client) throws IOException;
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchByReviewersPRsSource.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchByReviewersPRsSource.java
@@ -22,7 +22,7 @@ public class SearchByReviewersPRsSource implements SearchAsSourceInterface <GitH
     }
 
     @Override
-    public ArrayList<GitHubIssue> get(GHRepository repo, GitHub client) throws IOException {
+    public List<GitHubIssue> get(GHRepository repo, GitHub client) throws IOException {
         HashMap<Integer, GitHubIssue> issues = new HashMap<>();
 
         findIssues(client, repo, issues, source.getUsers(), "is:pr is:open repo:%s review-requested:%s");

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchIssuesSource.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/SearchIssuesSource.java
@@ -6,6 +6,7 @@ import com.bbaga.githubscheduledreminderapp.domain.sources.github.filters.Filter
 import com.bbaga.githubscheduledreminderapp.domain.sources.github.search.SearchIssueBuilder;
 import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
 import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubPullRequest;
+import java.util.List;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GitHub;
@@ -23,7 +24,7 @@ public class SearchIssuesSource implements SearchAsSourceInterface <GitHubIssue>
     }
 
     @Override
-    public ArrayList<GitHubIssue> get(GHRepository repo, GitHub client) throws IOException {
+    public List<GitHubIssue> get(GHRepository repo, GitHub client) throws IOException {
         HashMap<Integer, GitHubIssue> issues = new HashMap<>();
 
         SearchIssueBuilder builder = SearchIssueBuilder.from(client.searchIssues());


### PR DESCRIPTION
### Changes
- Previous implementation expected to have sources defined in `config.sources`, this isn't necessary anymore.
- Search source types can be used in the `config.sources` section as well