### PR TITLE
Set message content with .text() OR .blocks(), not both

### DIFF
--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelMessageBuilder.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelMessageBuilder.java
@@ -13,6 +13,7 @@ import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.SectionBlock;
 import com.slack.api.model.block.element.ButtonElement;
 import java.util.Map;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +111,8 @@ public class ChannelMessageBuilder implements ChannelMessageBuilderInterface {
         }
 
         var processedText = text.replaceAll("\\$login", login)
-            .replaceAll("\\$mergeableEmoji", mergeableEmoji)
-            .replaceAll("\\$title", pullRequest.getTitle())
+            .replaceAll("\\$mergeableEmoji", Matcher.quoteReplacement(mergeableEmoji))
+            .replaceAll("\\$title", Matcher.quoteReplacement(pullRequest.getTitle()))
             .replaceAll("\\$repository", pullRequest.getRepository().getFullName())
             .replaceAll("\\$age", getIssueAge(pullRequest))
             .replaceAll("\\$deletions", String.valueOf(deletions))

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/notifications/slack/ChannelNotification.java
@@ -215,25 +215,27 @@ public class ChannelNotification implements NotificationInterface<ChannelNotific
         var requestBuilder = ChatPostMessageRequest.builder()
             .channel(slackChannel);
 
-        List<String> textPieces = sections.stream().map(block -> {
-            TextObject text = null;
+        if (templateConfig.getMode().equals(TemplateConfig.MODE_FREE_TEXT)) {
+            List<String> textPieces = sections.stream().map(block -> {
+                TextObject text = null;
 
-            if (block instanceof HeaderBlock) {
-                text = ((HeaderBlock) block).getText();
-            }
+                if (block instanceof HeaderBlock) {
+                    text = ((HeaderBlock) block).getText();
+                }
 
-            if (block instanceof SectionBlock) {
-                text = ((SectionBlock) block).getText();
-            }
+                if (block instanceof SectionBlock) {
+                    text = ((SectionBlock) block).getText();
+                }
 
-            if (text != null) {
-                return text.getText();
-            }
+                if (text != null) {
+                    return text.getText();
+                }
 
-            return null;
-        }).filter(Objects::nonNull).collect(Collectors.toList());
+                return null;
+            }).filter(Objects::nonNull).collect(Collectors.toList());
 
-        requestBuilder.text(String.join("\n", textPieces));
+            requestBuilder.text(String.join("\n", textPieces));
+        }
 
         if (templateConfig.getMode().equals(TemplateConfig.MODE_BLOCK)) {
             requestBuilder.blocks(sections);


### PR DESCRIPTION
Some Slack Workspaces will duplicate messages when the .text() method is used to set the fallback text while using blocks.

The reason needs further investigation.