### PR TITLE
Implement path filtering

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -144,3 +144,19 @@ filters:
       - usernameA
       - usernameB
 ```
+
+### Path-filter
+This filter will remove the PRs and Issues based on whether the modified files in the PR start with the given paths.
+
+```yaml
+filters:
+  - type: path-filter
+    include:
+      - src/foo
+```
+
+The example above would match the following paths:
+
+ - `src/foo`
+ - `src/foo.txt`
+ - `src/foo/bar`

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/SourceConfig.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/SourceConfig.java
@@ -4,6 +4,7 @@ import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters
 import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.AuthorFilterConfig;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.DraftFilterConfig;
 import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.LabelFilterConfig;
+import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.PathFilterConfig;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -36,6 +37,7 @@ public abstract class SourceConfig {
             @JsonSubTypes.Type(value = DraftFilterConfig.class, name = DRAFT_FILTER),
             @JsonSubTypes.Type(value = LabelFilterConfig.class, name = LABEL_FILTER),
             @JsonSubTypes.Type(value = AuthorFilterConfig.class, name = AUTHOR_FILTER),
+            @JsonSubTypes.Type(value = PathFilterConfig.class, name = PATH_FILTER),
     })
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
     protected ArrayList<AbstractFilterConfig> filters;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/filters/Filters.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/filters/Filters.java
@@ -3,7 +3,8 @@ package com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filter
 public enum Filters {
     DRAFT_FILTER(Constants.DRAFT_FILTER),
     LABEL_FILTER(Constants.LABEL_FILTER),
-    AUTHOR_FILTER(Constants.AUTHOR_FILTER);
+    AUTHOR_FILTER(Constants.AUTHOR_FILTER),
+    PATH_FILTER(Constants.PATH_FILTER);
 
     public final String label;
 
@@ -15,5 +16,6 @@ public enum Filters {
         public static final String DRAFT_FILTER = "draft-filter";
         public static final String LABEL_FILTER = "label-filter";
         public static final String AUTHOR_FILTER = "author-filter";
+        public static final String PATH_FILTER = "path-filter";
     }
 }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/filters/PathFilterConfig.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/configuration/sources/filters/PathFilterConfig.java
@@ -1,0 +1,26 @@
+package com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PathFilterConfig extends AbstractFilterConfig {
+    @JsonProperty("include")
+    private List<String> includePaths;
+
+    public PathFilterConfig() {
+        super(Filters.PATH_FILTER.label);
+        includePaths = new ArrayList<>();
+    }
+
+    public List<String> getIncludePaths() {
+        return includePaths;
+    }
+
+    public void setIncludePaths(List<String> includePaths) {
+        this.includePaths = includePaths;
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/FilterProvider.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/FilterProvider.java
@@ -14,6 +14,8 @@ public class FilterProvider {
             filter = new LabelFilter();
         } else if (type.equals(Filters.AUTHOR_FILTER.label)) {
             filter = new AuthorFilter();
+        } else if (type.equals(Filters.PATH_FILTER.label)) {
+            filter = new PathFilter();
         } else {
             throw new RuntimeException(String.format("Unknown filter type: \"%s\"", type));
         }

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/PathFilter.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/PathFilter.java
@@ -30,7 +30,7 @@ public class PathFilter implements IssueFilterInterface {
         }
 
         try {
-            for (var file : pullRequest.listFileNames()) {
+            for (var file : pullRequest.getFilenames()) {
                 for (var includePath : includePaths) {
                     if (file.startsWith(includePath)) {
                         return false;

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/PathFilter.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/filters/PathFilter.java
@@ -1,0 +1,44 @@
+package com.bbaga.githubscheduledreminderapp.domain.sources.github.filters;
+
+import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.AbstractFilterConfig;
+import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.PathFilterConfig;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubPullRequest;
+
+import java.io.IOException;
+
+public class PathFilter implements IssueFilterInterface {
+    private PathFilterConfig config;
+
+    @Override
+    public void configure(AbstractFilterConfig config) {
+        this.config = (PathFilterConfig) config;
+    }
+
+    @Override
+    public Boolean filter(GitHubIssue issue) {
+        // Issues don't contain files, so ignore this filter
+        return false;
+    }
+
+    @Override
+    public Boolean filter(GitHubPullRequest pullRequest) {
+        var includePaths = config.getIncludePaths();
+        if (includePaths == null || includePaths.isEmpty()) {
+            // Nothing to filter by, so ignore this filter
+            return false;
+        }
+
+        try {
+            for (var file : pullRequest.listFileNames()) {
+                for (var includePath : includePaths) {
+                    if (file.startsWith(includePath)) {
+                        return false;
+                    }
+                }
+            }
+        } catch (IOException ignore) {}
+
+        return true;
+    }
+}

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
@@ -1,10 +1,9 @@
 package com.bbaga.githubscheduledreminderapp.infrastructure.github;
 
 import org.kohsuke.github.GHPullRequest;
-import org.kohsuke.github.GHPullRequestFileDetail;
 
 import java.io.IOException;
-import java.util.stream.Collectors;
+import java.util.Iterator;
 
 public class GitHubPullRequest extends GitHubIssue {
     private final GHPullRequest pullRequest;
@@ -33,8 +32,20 @@ public class GitHubPullRequest extends GitHubIssue {
         return pullRequest.isDraft();
     }
 
-    public Iterable<String> listFileNames() throws IOException {
-        return pullRequest.listFiles().withPageSize(100).toSet().stream().map(GHPullRequestFileDetail::getFilename).collect(Collectors.toSet());
+    public Iterable<String> getFilenames() throws IOException {
+        var iterator = pullRequest.listFiles().withPageSize(100).iterator();
+
+        return () -> new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public String next() {
+                return iterator.next().getFilename();
+            }
+        };
     }
 
     public GHPullRequest unwrap() {

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
@@ -1,8 +1,10 @@
 package com.bbaga.githubscheduledreminderapp.infrastructure.github;
 
 import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestFileDetail;
 
 import java.io.IOException;
+import java.util.stream.Collectors;
 
 public class GitHubPullRequest extends GitHubIssue {
     private final GHPullRequest pullRequest;
@@ -29,6 +31,10 @@ public class GitHubPullRequest extends GitHubIssue {
 
     public Boolean isDraft() throws IOException {
         return pullRequest.isDraft();
+    }
+
+    public Iterable<String> listFileNames() throws IOException {
+        return pullRequest.listFiles().toSet().stream().map(GHPullRequestFileDetail::getFilename).collect(Collectors.toSet());
     }
 
     public GHPullRequest unwrap() {

--- a/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
+++ b/src/main/java/com/bbaga/githubscheduledreminderapp/infrastructure/github/GitHubPullRequest.java
@@ -34,7 +34,7 @@ public class GitHubPullRequest extends GitHubIssue {
     }
 
     public Iterable<String> listFileNames() throws IOException {
-        return pullRequest.listFiles().toSet().stream().map(GHPullRequestFileDetail::getFilename).collect(Collectors.toSet());
+        return pullRequest.listFiles().withPageSize(100).toSet().stream().map(GHPullRequestFileDetail::getFilename).collect(Collectors.toSet());
     }
 
     public GHPullRequest unwrap() {

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/PathFilterTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/PathFilterTest.java
@@ -20,7 +20,7 @@ public class PathFilterTest {
 
         // No paths configured
         GitHubPullRequest pr = Mockito.mock(GitHubPullRequest.class);
-        Mockito.when(pr.listFileNames()).thenReturn(Arrays.asList("src/foo/foo.java", "src/bar/bar.java"));
+        Mockito.when(pr.getFilenames()).thenReturn(Arrays.asList("src/foo/foo.java", "src/bar/bar.java"));
         Assertions.assertFalse(filter.filter(pr));
 
         // Exact matching path configured
@@ -43,7 +43,7 @@ public class PathFilterTest {
         filter.configure(config);
 
         GitHubPullRequest pr = Mockito.mock(GitHubPullRequest.class);
-        Mockito.when(pr.listFileNames()).thenThrow(IOException.class);
+        Mockito.when(pr.getFilenames()).thenThrow(IOException.class);
         Assertions.assertFalse(filter.filter(pr));
     }
 

--- a/src/test/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/PathFilterTest.java
+++ b/src/test/java/com/bbaga/githubscheduledreminderapp/domain/sources/github/PathFilterTest.java
@@ -1,0 +1,56 @@
+package com.bbaga.githubscheduledreminderapp.domain.sources.github;
+
+import com.bbaga.githubscheduledreminderapp.domain.configuration.sources.filters.PathFilterConfig;
+import com.bbaga.githubscheduledreminderapp.domain.sources.github.filters.PathFilter;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubIssue;
+import com.bbaga.githubscheduledreminderapp.infrastructure.github.GitHubPullRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.*;
+
+public class PathFilterTest {
+    @Test
+    void testFilterPR() throws IOException {
+        PathFilterConfig config = new PathFilterConfig();
+        PathFilter filter = new PathFilter();
+        filter.configure(config);
+
+        // No paths configured
+        GitHubPullRequest pr = Mockito.mock(GitHubPullRequest.class);
+        Mockito.when(pr.listFileNames()).thenReturn(Arrays.asList("src/foo/foo.java", "src/bar/bar.java"));
+        Assertions.assertFalse(filter.filter(pr));
+
+        // Exact matching path configured
+        config.setIncludePaths(List.of("src/foo/foo.java"));
+        Assertions.assertFalse(filter.filter(pr));
+
+        // Partial matching path configured
+        config.setIncludePaths(List.of("src/bar/"));
+        Assertions.assertFalse(filter.filter(pr));
+
+        // No matching path configured
+        config.setIncludePaths(List.of("test/"));
+        Assertions.assertTrue(filter.filter(pr));
+    }
+
+    @Test
+    void testFilterPRThrowIOException() throws IOException {
+        PathFilterConfig config = new PathFilterConfig();
+        PathFilter filter = new PathFilter();
+        filter.configure(config);
+
+        GitHubPullRequest pr = Mockito.mock(GitHubPullRequest.class);
+        Mockito.when(pr.listFileNames()).thenThrow(IOException.class);
+        Assertions.assertFalse(filter.filter(pr));
+    }
+
+    @Test
+    void testFilterIssue() throws IOException {
+        PathFilter filter = new PathFilter();
+        GitHubIssue issue = Mockito.mock(GitHubIssue.class);
+        Assertions.assertFalse(filter.filter(issue));
+    }
+}


### PR DESCRIPTION
When working with a large monorepo, it would be helpful to filter PRs to only those that modify certain paths.  For example, image we have two people working on three different teams:

 - `colinodell` is on `team1` and `team2`
 - `bbaga` is on `team1` and `team3`

And we have a monorepo with directories like:

 - `src/foo` - owned by `team1`
 - `src/bar` - owned by `team2`
 - `src/baz` - owned by `team3`

While it's fine to search for all PRs where `colinodell` and `bbaga` are reviewers, it would be great if the PR reminders could be sent to separate channels based on the path using a config like this:

```yaml
enabled: true
notifications:
  - name: reminder
    schedule: "0 0 7,12,17,21 ? * MON-FRI"
    type: slack/channel    
    timezone: "Europe/Berlin"
    config:
      channel: "team1"
    repositories:
      shared/monorepo:
        sources:
          - type: search-prs-by-reviewers
            users:
              - colinodell
              - bbaga
            filters:
              - type: path-filter
                include: ["src/foo"]
  - name: reminder
    schedule: "0 0 7,12,17,21 ? * MON-FRI"
    type: slack/channel    
    timezone: "Europe/Berlin"
    config:
      channel: "team2"
    repositories:
      shared/monorepo:
        sources:
          - type: search-prs-by-reviewers
            users:
              - colinodell
            filters:
              - type: path-filter
                include: ["src/bar"]
  - name: reminder
    schedule: "0 0 7,12,17,21 ? * MON-FRI"
    type: slack/channel    
    timezone: "Europe/Berlin"
    config:
      channel: "team3"
    repositories:
      shared/monorepo:
        sources:
          - type: search-prs-by-reviewers
            users:
              - bbaga
            filters:
              - type: path-filter
                include: ["src/baz"]
```

Without this filter, the `#team1` Slack channel would receive reminders for `team3` even though they don't own those files.